### PR TITLE
cannot switch back to default lang after switching to any other lang

### DIFF
--- a/website_lang_flags/views/website_lang_flags.xml
+++ b/website_lang_flags/views/website_lang_flags.xml
@@ -20,7 +20,8 @@
                             <t t-if="lang!=lg[0]">
                                 <li style="min-width: 50px;">
                                         <a t-att-href="url_for(request.httprequest.path + '?' + keep_query(), lang=lg[0])"
-                                        t-att-data-default-lang="'true' if lg[0] == website.default_lang_code else None">
+                                        t-att-data-default-lang="'true' if lg[0] == website.default_lang_code else None"
+                                        t-att-data-lang="lg[0]" class="js_change_lang">
                                             <img t-att-src="website.image_url(lg[2], 'flag_image')" height="20" width="30" t-att-title="lg[1]" />
                                         </a>
                                 </li>


### PR DESCRIPTION
lang from cookies always takes precedence if lang not specified in url.
so lang attribute + class js_change_lang must be specified on lang element.

listener of js_change_lang rewrites href by adding lang to it taken from
html element <a>.
